### PR TITLE
Change API URLs and set isNostra to true

### DIFF
--- a/content.js
+++ b/content.js
@@ -23,8 +23,8 @@ const htmlCode = {
 }
 
 const currentMapMode = localStorage['emcdynmapplus-mapmode'] ?? 'meganations'
-const isNostra = location.href.includes('nostra')
-const apiURL = 'https://api.earthmc.net/v4/aurora'
+const isNostra = true
+const apiURL = 'https://api.earthmc.net/v4'
 const proxyURL = 'https://proxy.killcors.com/?url='
 const chosenArchiveDate = parseInt(localStorage['emcdynmapplus-archive-date'])
 

--- a/main.js
+++ b/main.js
@@ -11,7 +11,7 @@ const htmlCode = {
 }
 
 const server = localStorage['emcdynmapplus-terra-nova-archive'] == 'true' ? 'nova' : 'aurora'
-const alliancesURL = 'https://emcstats.bot.nu/aurora/alliances'
+const alliancesURL = 'https://emcstats.bot.nu/nostra/alliances'
 const apiURL = 'https://api.earthmc.net/v4'
 const proxyURL = 'https://proxy.killcors.com/?url='
 const isNostra = true

--- a/main.js
+++ b/main.js
@@ -12,9 +12,9 @@ const htmlCode = {
 
 const server = localStorage['emcdynmapplus-terra-nova-archive'] == 'true' ? 'nova' : 'aurora'
 const alliancesURL = 'https://emcstats.bot.nu/aurora/alliances'
-const apiURL = 'https://api.earthmc.net/v4/aurora'
+const apiURL = 'https://api.earthmc.net/v4'
 const proxyURL = 'https://proxy.killcors.com/?url='
-const isNostra = location.href.includes('nostra')
+const isNostra = true
 const currentMapMode = localStorage['emcdynmapplus-mapmode'] ?? 'meganations'
 const chosenArchiveDate = parseInt(localStorage['emcdynmapplus-archive-date'])
 

--- a/userscript.user.js
+++ b/userscript.user.js
@@ -453,7 +453,7 @@ const { fetch: originalFetch } = unsafeWindow
 // Make this function work in userscript
 unsafeWindow.lookupPlayerFunc = lookupPlayer
 
-const alliancesURL = 'https://emcstats.bot.nu/aurora/alliances'
+const alliancesURL = 'https://emcstats.bot.nu/nostra/alliances'
 const server = localStorage['emcdynmapplus-terra-nova-archive'] == 'true' ? 'nova' : 'aurora'
 
 let alliances = null

--- a/userscript.user.js
+++ b/userscript.user.js
@@ -47,8 +47,8 @@ const htmlCode = {
 }
 
 const currentMapMode = localStorage['emcdynmapplus-mapmode'] ?? 'meganations'
-const isNostra = location.href.includes('nostra')
-const apiURL = 'https://api.earthmc.net/v4/aurora'
+const isNostra = true
+const apiURL = 'https://api.earthmc.net/v4'
 const proxyURL = 'https://proxy.killcors.com/?url='
 const chosenArchiveDate = parseInt(localStorage['emcdynmapplus-archive-date'])
 


### PR DESCRIPTION
Fixes the problem of player data not working in the extension currently, and has a quick fix of setting IsNostra to true, since this extension isn't currently configured to work on aurora.earthmc.net anyway. Also updates the alliancesURL it pulls from.

Also yes, I tested this and it worked. It will complain about not being able to download the country borders layer, but I don't care.

These are just meant to be quick fixes until 3meraldk can spend more time on this.